### PR TITLE
Feature/10th submission

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/PeriodType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/PeriodType.java
@@ -1,0 +1,14 @@
+package com.loopers.application.ranking;
+
+public enum PeriodType {
+    DAILY, WEEKLY, MONTHLY;
+
+    public static PeriodType from(String s) {
+        if (s == null) return DAILY;
+        return switch (s.toLowerCase()) {
+            case "weekly" -> WEEKLY;
+            case "monthly" -> MONTHLY;
+            default -> DAILY;
+        };
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -3,34 +3,26 @@ package com.loopers.application.ranking;
 import com.loopers.application.product.ProductFacade;
 import com.loopers.application.product.ProductInfo;
 import com.loopers.application.ranking.dto.RankingResult;
-import com.loopers.domain.ranking.MonthlyRankingMV;
-import com.loopers.domain.ranking.WeeklyRankingMV;
-import com.loopers.infrastructure.ranking.MonthlyRankingRepository;
-import com.loopers.infrastructure.ranking.WeeklyRankingRepository;
 import com.loopers.interfaces.api.ranking.ProductRankingInfo;
 import com.loopers.interfaces.api.ranking.RankingEntry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class RankingFacade {
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RankingService rankingService;
     private final ProductFacade productFacade;
-    private final WeeklyRankingRepository weeklyRepo;
-    private final MonthlyRankingRepository monthlyRepo;
+
 
     public RankingResult getRankings(PeriodType period, LocalDate targetDate, int page, int size) {
         int start = (page - 1) * size;
@@ -38,85 +30,24 @@ public class RankingFacade {
 
         log.info("랭킹 조회 시작 - period={}, date={}, page={}, size={}", period, targetDate, page, size);
 
-        RankingResult result;
+        RankingResult result = switch (period) {
+            case DAILY -> rankingService.getDailyRankings(targetDate, start, end);
+            case WEEKLY -> rankingService.getWeeklyRankings(targetDate, page, size);
+            case MONTHLY -> rankingService.getMonthlyRankings(targetDate, page, size);
+        };
 
-        switch (period) {
-            case DAILY -> {
-                // Redis (오늘 → 어제 → 그제)
-                result = fetchFromRedisWithFallback(targetDate, start, end);
-                if (!result.isEmpty()) {
-                    enrichEntriesWithProductInfo(result.getEntries());
-                    return result;
-                }
-                // 일간이 비어있으면 그냥 empty 반환
-                return RankingResult.builder()
-                    .actualDate(targetDate)
-                    .entries(List.of())
-                    .source("redis-empty")
-                    .build();
-            }
-            case WEEKLY -> {
-                result = fetchFromWeeklyDb(targetDate, page, size);
-                if (!result.isEmpty()) {
-                    enrichEntriesWithProductInfo(result.getEntries());
-                    return result;
-                }
-                // 주간 비면 empty
-                return RankingResult.builder()
-                    .actualDate(targetDate)
-                    .entries(List.of())
-                    .source("db-weekly-empty")
-                    .build();
-            }
-            case MONTHLY -> {
-                result = fetchFromMonthlyDb(targetDate, page, size);
-                if (!result.isEmpty()) {
-                    enrichEntriesWithProductInfo(result.getEntries());
-                    return result;
-                }
-                // 월간 비면 empty
-                return RankingResult.builder()
-                    .actualDate(targetDate)
-                    .entries(List.of())
-                    .source("db-monthly-empty")
-                    .build();
-            }
-            default -> {
-                // 방어 로직: 혹시 모르는 값이면 일간 규칙로
-                result = fetchFromRedisWithFallback(targetDate, start, end);
-                if (!result.isEmpty()) {
-                    enrichEntriesWithProductInfo(result.getEntries());
-                    return result;
-                }
-                return RankingResult.builder()
-                    .actualDate(targetDate)
-                    .entries(List.of())
-                    .source("unknown-period")
-                    .build();
-            }
+        // 상품 정보 보강
+        if (!result.isEmpty()) {
+            enrichEntriesWithProductInfo(result.getEntries());
         }
+
+        return result;
     }
 
-    // ====== 이하 기존 헬퍼들 유지 ======
 
     public ProductRankingInfo getProductRanking(Long productId, LocalDate targetDate) {
-        String member = "product:" + productId;
-        Long rank = null;
-        Double score = null;
-        LocalDate actual = targetDate;
-
-        for (int i = 0; i < 3; i++) {
-            LocalDate d = targetDate.minusDays(i);
-            String key = dailyKey(d);
-            Double s = redisTemplate.opsForZSet().score(key, member);
-            if (s != null) {
-                score = s;
-                Long r = redisTemplate.opsForZSet().reverseRank(key, member);
-                rank = (r == null) ? null : r + 1;
-                actual = d;
-                break;
-            }
-        }
+        RankingService.ProductRankingInfo rankingInfo = 
+            rankingService.getProductDailyRanking(productId, targetDate);
 
         ProductInfo productInfo = null;
         try {
@@ -127,152 +58,33 @@ public class RankingFacade {
         }
 
         return ProductRankingInfo.builder()
-            .productId(productId)
-            .date(actual)
-            .rank(rank)
-            .score(score)
+            .productId(rankingInfo.productId())
+            .date(rankingInfo.date())
+            .rank(rankingInfo.rank())
+            .score(rankingInfo.score())
             .productInfo(productInfo)
             .build();
     }
 
-    private RankingResult fetchFromRedisWithFallback(LocalDate targetDate, int start, int end) {
-        for (int i = 0; i < 3; i++) {
-            LocalDate d = targetDate.minusDays(i);
-            String key = dailyKey(d);
-            Set<TypedTuple<String>> tuples =
-                redisTemplate.opsForZSet().reverseRangeWithScores(key, start, end);
-            if (tuples != null && !tuples.isEmpty()) {
-                List<RankingEntry> entries = tuples.stream()
-                    .map(t -> RankingEntry.builder()
-                        .productId(parseProductId(t.getValue()))
-                        .score(t.getScore() == null ? 0.0 : t.getScore())
-                        .productInfo(null)
-                        .build())
-                    .filter(e -> e.getProductId() != null)
-                    .collect(Collectors.toList());
-                String src = (i == 0) ? "redis" : (i == 1 ? "redis-fallback-yesterday" : "redis-fallback-day-before");
-                return RankingResult.builder()
-                    .actualDate(d)
-                    .entries(entries)
-                    .source(src)
-                    .build();
-            }
-        }
-        return RankingResult.builder()
-            .actualDate(targetDate)
-            .entries(List.of())
-            .source("redis-empty")
-            .build();
-    }
-
-    private RankingResult fetchFromWeeklyDb(LocalDate targetDate, int page, int size) {
-        Pageable pageable = PageRequest.of(page - 1, size);
-        List<WeeklyRankingMV> rows = weeklyRepo.findByTargetDateOrderByRankNoAsc(targetDate, pageable);
-
-        LocalDate actual = targetDate;
-        String source = "db-weekly";
-
-        if (rows == null || rows.isEmpty()) {
-            LocalDate latest = weeklyRepo.findLatestTargetDate(targetDate);
-            if (latest == null) {
-                return RankingResult.builder()
-                    .actualDate(targetDate)
-                    .entries(List.of())
-                    .source("db-weekly-empty")
-                    .build();
-            }
-            rows = weeklyRepo.findByTargetDateOrderByRankNoAsc(latest, pageable);
-            actual = latest;
-            source = "db-weekly-fallback";
-        }
-
-        List<RankingEntry> entries = rows.stream()
-            .map(this::toEntryFromWeekly)
-            .collect(Collectors.toList());
-
-        return RankingResult.builder()
-            .actualDate(actual)
-            .entries(entries)
-            .source(source)
-            .build();
-    }
-
-    private RankingResult fetchFromMonthlyDb(LocalDate targetDate, int page, int size) {
-        Pageable pageable = PageRequest.of(page - 1, size);
-        List<MonthlyRankingMV> rows = monthlyRepo.findByTargetDateOrderByRankNoAsc(targetDate, pageable);
-
-        LocalDate actual = targetDate;
-        String source = "db-monthly";
-
-        if (rows == null || rows.isEmpty()) {
-            LocalDate latest = monthlyRepo.findLatestTargetDate(targetDate);
-            if (latest == null) {
-                return RankingResult.builder()
-                    .actualDate(targetDate)
-                    .entries(List.of())
-                    .source("db-monthly-empty")
-                    .build();
-            }
-            rows = monthlyRepo.findByTargetDateOrderByRankNoAsc(latest, pageable);
-            actual = latest;
-            source = "db-monthly-fallback";
-        }
-
-        List<RankingEntry> entries = rows.stream()
-            .map(this::toEntryFromMonthly)
-            .collect(Collectors.toList());
-
-        return RankingResult.builder()
-            .actualDate(actual)
-            .entries(entries)
-            .source(source)
-            .build();
-    }
-
-    private RankingEntry toEntryFromWeekly(WeeklyRankingMV mv) {
-        return RankingEntry.builder()
-            .productId(mv.getProductId())
-            .score(mv.getRankingScore()) // 필드명에 맞게
-            .productInfo(null)
-            .build();
-    }
-
-    private RankingEntry toEntryFromMonthly(MonthlyRankingMV mv) {
-        return RankingEntry.builder()
-            .productId(mv.getProductId())
-            .score(mv.getRankingScore())
-            .productInfo(null)
-            .build();
-    }
-
+    /**
+     * 랭킹 엔트리에 상품 정보 보강
+     */
     private void enrichEntriesWithProductInfo(List<RankingEntry> entries) {
         if (entries == null || entries.isEmpty()) return;
-        List<Long> ids = entries.stream()
+
+        List<Long> productIds = entries.stream()
             .map(RankingEntry::getProductId)
             .filter(Objects::nonNull)
             .distinct()
             .toList();
+
         try {
-            Map<Long, ProductInfo> infoMap = productFacade.getProductInfoMap(ids);
-            for (RankingEntry e : entries) {
-                e.setProductInfo(infoMap.get(e.getProductId()));
+            Map<Long, ProductInfo> infoMap = productFacade.getProductInfoMap(productIds);
+            for (RankingEntry entry : entries) {
+                entry.setProductInfo(infoMap.get(entry.getProductId()));
             }
         } catch (Exception ex) {
             log.warn("상품정보 배치 조회 실패", ex);
-        }
-    }
-
-    private String dailyKey(LocalDate date) {
-        return "ranking:all:" + date.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-    }
-
-    private Long parseProductId(String member) {
-        if (member == null || !member.startsWith("product:")) return null;
-        try {
-            return Long.parseLong(member.substring(8));
-        } catch (NumberFormatException e) {
-            log.warn("잘못된 product member 형식: {}", member);
-            return null;
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingService.java
@@ -1,0 +1,25 @@
+package com.loopers.application.ranking;
+
+import com.loopers.application.ranking.dto.RankingResult;
+
+import java.time.LocalDate;
+
+/**
+ * 랭킹 조회 서비스 인터페이스
+ */
+public interface RankingService {
+
+
+    RankingResult getDailyRankings(LocalDate targetDate, int start, int end);
+
+
+    RankingResult getWeeklyRankings(LocalDate targetDate, int page, int size);
+
+
+    RankingResult getMonthlyRankings(LocalDate targetDate, int page, int size);
+
+    ProductRankingInfo getProductDailyRanking(Long productId, LocalDate targetDate);
+
+
+    record ProductRankingInfo(Long productId, LocalDate date, Long rank, Double score) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingServiceImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingServiceImpl.java
@@ -1,0 +1,205 @@
+package com.loopers.application.ranking;
+
+import com.loopers.application.ranking.dto.RankingResult;
+import com.loopers.domain.ranking.MonthlyRankingMV;
+import com.loopers.domain.ranking.WeeklyRankingMV;
+import com.loopers.infrastructure.ranking.MonthlyRankingRepository;
+import com.loopers.infrastructure.ranking.WeeklyRankingRepository;
+import com.loopers.interfaces.api.ranking.RankingEntry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 랭킹 조회 서비스 구현체
+ * - Redis(일간), DB(주간/월간) 데이터 조회
+ * - Fallback 로직 처리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingServiceImpl implements RankingService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final WeeklyRankingRepository weeklyRepo;
+    private final MonthlyRankingRepository monthlyRepo;
+
+    @Override
+    public RankingResult getDailyRankings(LocalDate targetDate, int start, int end) {
+        return fetchFromRedisWithFallback(targetDate, start, end);
+    }
+
+    @Override
+    public RankingResult getWeeklyRankings(LocalDate targetDate, int page, int size) {
+        return fetchFromWeeklyDb(targetDate, page, size);
+    }
+
+    @Override
+    public RankingResult getMonthlyRankings(LocalDate targetDate, int page, int size) {
+        return fetchFromMonthlyDb(targetDate, page, size);
+    }
+
+    @Override
+    public ProductRankingInfo getProductDailyRanking(Long productId, LocalDate targetDate) {
+        String member = "product:" + productId;
+        Long rank = null;
+        Double score = null;
+        LocalDate actual = targetDate;
+
+        // 3일간 fallback 조회
+        for (int i = 0; i < 3; i++) {
+            LocalDate d = targetDate.minusDays(i);
+            String key = dailyKey(d);
+            Double s = redisTemplate.opsForZSet().score(key, member);
+            if (s != null) {
+                score = s;
+                Long r = redisTemplate.opsForZSet().reverseRank(key, member);
+                rank = (r == null) ? null : r + 1;
+                actual = d;
+                break;
+            }
+        }
+
+        return new ProductRankingInfo(productId, actual, rank, score);
+    }
+
+    // ===== Private Methods =====
+
+    private RankingResult fetchFromRedisWithFallback(LocalDate targetDate, int start, int end) {
+        for (int i = 0; i < 3; i++) {
+            LocalDate d = targetDate.minusDays(i);
+            String key = dailyKey(d);
+            Set<TypedTuple<String>> tuples =
+                redisTemplate.opsForZSet().reverseRangeWithScores(key, start, end);
+            if (tuples != null && !tuples.isEmpty()) {
+                List<RankingEntry> entries = tuples.stream()
+                    .map(t -> RankingEntry.builder()
+                        .productId(parseProductId(t.getValue()))
+                        .score(t.getScore() == null ? 0.0 : t.getScore())
+                        .productInfo(null)
+                        .build())
+                    .filter(e -> e.getProductId() != null)
+                    .collect(Collectors.toList());
+                String src = switch (i) {
+                    case 0 -> "redis";
+                    case 1 -> "redis-fallback-yesterday";
+                    default -> "redis-fallback-day-before";
+                };
+                return RankingResult.builder()
+                    .actualDate(d)
+                    .entries(entries)
+                    .source(src)
+                    .build();
+            }
+        }
+        return RankingResult.builder()
+            .actualDate(targetDate)
+            .entries(List.of())
+            .source("redis-empty")
+            .build();
+    }
+
+    private RankingResult fetchFromWeeklyDb(LocalDate targetDate, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        List<WeeklyRankingMV> rows = weeklyRepo.findByTargetDateOrderByRankNoAsc(targetDate, pageable);
+
+        LocalDate actual = targetDate;
+        String source = "db-weekly";
+
+        if (rows == null || rows.isEmpty()) {
+            LocalDate latest = weeklyRepo.findLatestTargetDate(targetDate);
+            if (latest == null) {
+                return RankingResult.builder()
+                    .actualDate(targetDate)
+                    .entries(List.of())
+                    .source("db-weekly-empty")
+                    .build();
+            }
+            rows = weeklyRepo.findByTargetDateOrderByRankNoAsc(latest, pageable);
+            actual = latest;
+            source = "db-weekly-fallback";
+        }
+
+        List<RankingEntry> entries = rows.stream()
+            .map(this::toEntryFromWeekly)
+            .collect(Collectors.toList());
+
+        return RankingResult.builder()
+            .actualDate(actual)
+            .entries(entries)
+            .source(source)
+            .build();
+    }
+
+    private RankingResult fetchFromMonthlyDb(LocalDate targetDate, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        List<MonthlyRankingMV> rows = monthlyRepo.findByTargetDateOrderByRankNoAsc(targetDate, pageable);
+
+        LocalDate actual = targetDate;
+        String source = "db-monthly";
+
+        if (rows == null || rows.isEmpty()) {
+            LocalDate latest = monthlyRepo.findLatestTargetDate(targetDate);
+            if (latest == null) {
+                return RankingResult.builder()
+                    .actualDate(targetDate)
+                    .entries(List.of())
+                    .source("db-monthly-empty")
+                    .build();
+            }
+            rows = monthlyRepo.findByTargetDateOrderByRankNoAsc(latest, pageable);
+            actual = latest;
+            source = "db-monthly-fallback";
+        }
+
+        List<RankingEntry> entries = rows.stream()
+            .map(this::toEntryFromMonthly)
+            .collect(Collectors.toList());
+
+        return RankingResult.builder()
+            .actualDate(actual)
+            .entries(entries)
+            .source(source)
+            .build();
+    }
+
+    private RankingEntry toEntryFromWeekly(WeeklyRankingMV mv) {
+        return RankingEntry.builder()
+            .productId(mv.getProductId())
+            .score(mv.getRankingScore())
+            .productInfo(null)
+            .build();
+    }
+
+    private RankingEntry toEntryFromMonthly(MonthlyRankingMV mv) {
+        return RankingEntry.builder()
+            .productId(mv.getProductId())
+            .score(mv.getRankingScore())
+            .productInfo(null)
+            .build();
+    }
+
+    private String dailyKey(LocalDate date) {
+        return "ranking:all:" + date.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+    }
+
+    private Long parseProductId(String member) {
+        if (member == null || !member.startsWith("product:")) return null;
+        try {
+            return Long.parseLong(member.substring(8));
+        } catch (NumberFormatException e) {
+            log.warn("잘못된 product member 형식: {}", member);
+            return null;
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/dto/RankingResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/dto/RankingResult.java
@@ -1,0 +1,20 @@
+package com.loopers.application.ranking.dto;
+
+import com.loopers.interfaces.api.ranking.RankingEntry;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.*;
+
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RankingResult {
+    private LocalDate actualDate;
+    private List<RankingEntry> entries;
+    private String source; // "redis" | "db-weekly" | "db-monthly" | "empty"
+
+    public boolean isEmpty() {
+        return entries == null || entries.isEmpty();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MonthlyRankingMV.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MonthlyRankingMV.java
@@ -1,0 +1,48 @@
+// MonthlyRankingMV.java
+package com.loopers.domain.ranking;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Immutable;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@Entity
+@Immutable
+@Table(name = "mv_product_rank_monthly",
+    indexes = {
+        @Index(name = "idx_m_target_rank", columnList = "target_date, rank_no"),
+        @Index(name = "idx_m_product_target", columnList = "product_id, target_date")
+    })
+public class MonthlyRankingMV extends BaseEntity {
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "rank_no", nullable = false)
+    private Integer rankNo;
+
+    @Column(name = "ranking_score", nullable = false)
+    private Double rankingScore;
+
+    @Column(name = "target_date", nullable = false)
+    private LocalDate targetDate;
+
+    @Column(name = "period_start_date")
+    private LocalDate periodStartDate;
+
+    @Column(name = "period_end_date")
+    private LocalDate periodEndDate;
+
+    @Column(name = "like_count")
+    private Long likeCount;
+
+    @Column(name = "order_count")
+    private Long orderCount;
+
+    @Column(name = "view_count")
+    private Long viewCount;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/WeeklyRankingMV.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/WeeklyRankingMV.java
@@ -1,0 +1,50 @@
+// WeeklyRankingMV.java
+package com.loopers.domain.ranking;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Immutable;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@Entity
+@Immutable // MV 스냅샷이면 읽기 전용 권장
+@Table(name = "mv_product_rank_weekly",
+    indexes = {
+        @Index(name = "idx_w_target_rank", columnList = "target_date, rank_no"),
+        @Index(name = "idx_w_product_target", columnList = "product_id, target_date")
+    })
+public class WeeklyRankingMV extends BaseEntity {
+
+    // BaseEntity에 id가 있다면 여기서 id 선언하지 마!
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "rank_no", nullable = false)
+    private Integer rankNo;
+
+    @Column(name = "ranking_score", nullable = false)
+    private Double rankingScore;
+
+    @Column(name = "target_date", nullable = false)
+    private LocalDate targetDate;
+
+    @Column(name = "period_start_date")
+    private LocalDate periodStartDate;
+
+    @Column(name = "period_end_date")
+    private LocalDate periodEndDate;
+
+    @Column(name = "like_count")
+    private Long likeCount;
+
+    @Column(name = "order_count")
+    private Long orderCount;
+
+    @Column(name = "view_count")
+    private Long viewCount;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingRepository.java
@@ -5,6 +5,7 @@ import com.loopers.domain.ranking.MonthlyRankingMV;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -15,5 +16,5 @@ public interface MonthlyRankingRepository extends JpaRepository<MonthlyRankingMV
     Optional<MonthlyRankingMV> findByProductIdAndTargetDate(Long productId, LocalDate targetDate);
 
     @Query("select max(m.targetDate) from MonthlyRankingMV m where m.targetDate <= :targetDate")
-    LocalDate findLatestTargetDate(LocalDate targetDate);
+    LocalDate findLatestTargetDate(@Param("targetDate") LocalDate targetDate);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingRepository.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.ranking;
+
+
+import com.loopers.domain.ranking.MonthlyRankingMV;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface MonthlyRankingRepository extends JpaRepository<MonthlyRankingMV, Long> {
+    List<MonthlyRankingMV> findByTargetDateOrderByRankNoAsc(LocalDate targetDate, Pageable pageable);
+    Optional<MonthlyRankingMV> findByProductIdAndTargetDate(Long productId, LocalDate targetDate);
+
+    @Query("select max(m.targetDate) from MonthlyRankingMV m where m.targetDate <= :targetDate")
+    LocalDate findLatestTargetDate(LocalDate targetDate);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingRepository.java
@@ -1,0 +1,18 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.WeeklyRankingMV;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface WeeklyRankingRepository extends JpaRepository<WeeklyRankingMV, Long> {
+    List<WeeklyRankingMV> findByTargetDateOrderByRankNoAsc(LocalDate targetDate, Pageable pageable);
+    Optional<WeeklyRankingMV> findByProductIdAndTargetDate(Long productId, LocalDate targetDate);
+
+    @Query("select max(w.targetDate) from WeeklyRankingMV w where w.targetDate <= :targetDate")
+    LocalDate findLatestTargetDate(LocalDate targetDate);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/ProductRankingInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/ProductRankingInfo.java
@@ -1,22 +1,22 @@
 package com.loopers.interfaces.api.ranking;
 
+import com.loopers.application.product.ProductInfo;
 import java.time.LocalDate;
+import lombok.*;
 
-/**
- * 개별 상품의 랭킹 정보
- */
-public record ProductRankingInfo(
-    Long productId,
-    LocalDate date,
-    Long rank,      // 순위 (1-based, null이면 랭킹 없음)
-    Double score    // 점수 (null이면 점수 없음)
-) {
-    
-    public static ProductRankingInfo of(Long productId, LocalDate date, Long rank, Double score) {
-        return new ProductRankingInfo(productId, date, rank, score);
-    }
-    
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductRankingInfo {
+    private Long productId;
+    private LocalDate date;
+    private Long rank;          // 1-based, null이면 없음
+    private Double score;       // null이면 없음
+    private ProductInfo productInfo;
+
     public boolean isInRanking() {
         return rank != null && score != null;
     }
 }
+

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
@@ -31,8 +31,10 @@ public class RankingController {
         @RequestParam(defaultValue = "20") int size,
         @RequestParam(defaultValue = "1") int page
     ) {
-        if (page < 1) page = 1;
-        if (size < 1) size = 20;
+        final int MAX_PAGE_SIZE = 100;
+        page = Math.max(page, 1);
+        size = Math.max(size, 1);
+        size = Math.min(size, MAX_PAGE_SIZE);
 
         PeriodType p = PeriodType.from(period);
         LocalDate targetDate = parseDate(date);

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingEntry.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingEntry.java
@@ -1,12 +1,23 @@
 package com.loopers.interfaces.api.ranking;
 
 import com.loopers.application.product.ProductInfo;
+import lombok.Setter;
 
-/**
- * 랭킹 엔트리 (상품 정보 포함)
- */
-public record RankingEntry(
-    Long productId,
-    Double score,
-    ProductInfo productInfo  // 상품 메타데이터 (이름, 가격, 이미지 등)
-) {}
+import com.loopers.application.product.ProductInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RankingEntry {
+
+    private Long productId;
+    private Double score;
+    private ProductInfo productInfo; // 상세(이름/가격/브랜드 등)
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/ranking/WeightManager.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/ranking/WeightManager.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
+import java.util.Set;
 /**
  * Redis 기반 랭킹 가중치 관리자
  * 

--- a/apps/ranking-batch/README.md
+++ b/apps/ranking-batch/README.md
@@ -1,0 +1,31 @@
+# Ranking Batch
+
+Spring Batch 기반 상품 랭킹 시스템
+
+## 기능
+- Daily 랭킹 집계 (event_metrics → mv_product_rank_daily)  
+- Weekly Top 100 랭킹 생성 (7일치 집계)
+- Monthly Top 100 랭킹 생성 (30일치 집계)
+- Redis 캐시 발행
+
+## 배치 실행 스케줄
+- Daily: 매일 새벽 2시
+- Weekly: 매주 월요일 새벽 3시  
+- Monthly: 매월 1일 새벽 4시
+
+## 실행 방법
+```bash
+# 애플리케이션 실행
+./gradlew :apps:ranking-batch:bootRun
+
+# 수동 배치 실행 (개발용)
+# Daily: java -jar ranking-batch.jar --job.name=dailyRankingJob date=2024-09-18
+# Weekly: java -jar ranking-batch.jar --job.name=weeklyRankingJob yearWeek=2024W38
+# Monthly: java -jar ranking-batch.jar --job.name=monthlyRankingJob yearMonth=202409
+```
+
+## 주요 클래스
+- `RankingBatchApplication.java`: 메인 애플리케이션
+- `DailyRankingJobConfig.java`: Daily 집계 배치
+- `WeeklyRankingJobConfig.java`: Weekly Top 100 배치
+- `MonthlyRankingJobConfig.java`: Monthly Top 100 배치

--- a/apps/ranking-batch/build.gradle.kts
+++ b/apps/ranking-batch/build.gradle.kts
@@ -35,7 +35,8 @@ dependencies {
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.batch:spring-batch-test")
-    testImplementation("com.h2database:h2")
+    testImplementation("org.testcontainers:mysql")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
 }
 
 tasks.withType<Test> {

--- a/apps/ranking-batch/build.gradle.kts
+++ b/apps/ranking-batch/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+    id("org.jetbrains.kotlin.jvm")
+    id("org.jetbrains.kotlin.plugin.spring")
+    id("org.jetbrains.kotlin.plugin.jpa")
+}
+
+group = "com.loopers"
+version = "0.0.1-SNAPSHOT"
+
+dependencies {
+    // 공통 모듈 의존성
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+    
+    // EventMetric 엔티티 접근을 위한 의존성
+    implementation(project(":apps:commerce-streamer"))
+    
+    // Spring Boot Batch
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    
+    // Database
+    runtimeOnly("com.mysql:mysql-connector-j")
+    
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+    
+    // Test
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.batch:spring-batch-test")
+    testImplementation("com.h2database:h2")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/RankingBatchApplication.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/RankingBatchApplication.java
@@ -1,0 +1,16 @@
+package com.loopers.batch;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableBatchProcessing
+@EnableScheduling
+public class RankingBatchApplication {
+    
+    public static void main(String[] args) {
+        SpringApplication.run(RankingBatchApplication.class, args);
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/RankingBatchApplication.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/RankingBatchApplication.java
@@ -3,9 +3,16 @@ package com.loopers.batch;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {
+    "com.loopers.batch",     // 배치 모듈
+    "com.loopers.config.jpa" // JPA 모듈의 Configuration (DataSourceConfig 포함)
+})
+@EnableJpaRepositories(basePackages = "com.loopers.batch.repository")
+@EntityScan(basePackages = "com.loopers.batch.domain.entity")
 @EnableBatchProcessing
 @EnableScheduling
 public class RankingBatchApplication {

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/config/DailyRankingJobConfig.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/config/DailyRankingJobConfig.java
@@ -1,0 +1,90 @@
+package com.loopers.batch.config;
+
+import com.loopers.batch.domain.dto.DailyMetricsDto;
+import com.loopers.batch.domain.entity.DailyRankingMV;
+import com.loopers.batch.job.processor.DailyRankingProcessor;
+import com.loopers.batch.job.reader.EventMetricsCursorReader;
+import com.loopers.batch.job.writer.DailyRankingWriter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class DailyRankingJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final EventMetricsCursorReader readerFactory;
+    private final DailyRankingProcessor processor;
+    private final DailyRankingWriter writer;
+
+    @Value("${batch.chunk-size:1000}")
+    private int chunkSize;
+
+    @Bean
+    public Job dailyRankingJob() {
+        return new JobBuilder("dailyRankingJob", jobRepository)
+            .start(dailyRankingStep())
+            .incrementer(new RunIdIncrementer())
+            .listener(dailyRankingJobListener())
+            .build();
+    }
+
+    @Bean
+    public Step dailyRankingStep() {
+        return new StepBuilder("dailyRankingStep", jobRepository)
+            .<DailyMetricsDto, DailyRankingMV>chunk(chunkSize, transactionManager)
+            .reader(readerFactory.dailyMetricsReader(null, null)) // 실제 실행 시점에 주입됨
+            .processor(processor)
+            .writer(writer)
+            .listener(writer) // Writer가 StepExecutionListener도 구현
+            .build();
+    }
+
+    @Bean
+    public JobExecutionListener dailyRankingJobListener() {
+        return new JobExecutionListener() {
+            @Override
+            public void beforeJob(JobExecution jobExecution) {
+                String targetDate = jobExecution.getJobParameters().getString("targetDate");
+                log.info("=== 일별 랭킹 배치 시작 ===");
+                log.info("대상 날짜: {}", targetDate);
+                log.info("청크 크기: {}", chunkSize);
+                jobExecution.getExecutionContext().put("startTime", LocalDateTime.now());
+            }
+
+            @Override
+            public void afterJob(JobExecution jobExecution) {
+                LocalDateTime startTime = (LocalDateTime) jobExecution.getExecutionContext().get("startTime");
+                Duration duration = Duration.between(startTime, LocalDateTime.now());
+
+                log.info("=== 일별 랭킹 배치 완료 ===");
+                log.info("실행 시간: {}초", duration.toSeconds());
+                log.info("최종 상태: {}", jobExecution.getStatus());
+
+                if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
+                    // 처리된 건수 조회
+                    jobExecution.getStepExecutions().forEach(step -> {
+                        int processedCount = step.getExecutionContext().getInt("processedCount", 0);
+                        log.info("처리 완료 - Step: {}, 처리 건수: {}", step.getStepName(), processedCount);
+                    });
+                }
+            }
+        };
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/config/MonthlyRankingJobConfig.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/config/MonthlyRankingJobConfig.java
@@ -1,0 +1,74 @@
+package com.loopers.batch.config;
+
+import com.loopers.batch.domain.dto.MonthlyMetricsDto;
+import com.loopers.batch.domain.entity.MonthlyRankingMV;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class MonthlyRankingJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    @Value("${batch.chunk-size:1000}")
+    private int chunkSize;
+
+    @Bean
+    public Job monthlyRankingJob(Step monthlyRankingStep) {
+        return new JobBuilder("monthlyRankingJob", jobRepository)
+            .listener(monthlyJobListener())
+            .start(monthlyRankingStep)
+            .build();
+    }
+
+    @Bean
+    public Step monthlyRankingStep(
+        ItemReader<MonthlyMetricsDto> monthlyMetricsReader,
+        ItemProcessor<MonthlyMetricsDto, MonthlyRankingMV> monthlyRankingProcessor,
+        // 필요에 따라 단순저장/Top저장 택1
+        // ItemWriter<MonthlyRankingMV> monthlyRankingWriter
+        ItemWriter<MonthlyRankingMV> monthlyRankingTopWriter
+    ) {
+        return new StepBuilder("monthlyRankingStep", jobRepository)
+            .<MonthlyMetricsDto, MonthlyRankingMV>chunk(chunkSize, transactionManager)
+            .reader(monthlyMetricsReader)
+            .processor(monthlyRankingProcessor)
+            .writer(monthlyRankingTopWriter) // Top 100 저장 사용
+            .build();
+    }
+
+    private JobExecutionListener monthlyJobListener() {
+        return new JobExecutionListener() {
+            @Override
+            public void beforeJob(JobExecution jobExecution) {
+                String monthStart = jobExecution.getJobParameters().getString("monthStartDate");
+                log.info("=== 월간 랭킹 배치 시작 ===");
+                log.info("월 시작일(옵션): {}", monthStart);
+                log.info("청크 크기: {}", chunkSize);
+            }
+
+            @Override
+            public void afterJob(JobExecution jobExecution) {
+                long sec = java.time.Duration.between(
+                    jobExecution.getStartTime(), jobExecution.getEndTime()).toSeconds();
+                log.info("=== 월간 랭킹 배치 완료 ===");
+                log.info("실행 시간: {}초", sec);
+                log.info("최종 상태: {}", jobExecution.getStatus());
+            }
+        };
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/config/WeeklyRankingJobConfig.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/config/WeeklyRankingJobConfig.java
@@ -1,0 +1,78 @@
+package com.loopers.batch.config;
+
+import com.loopers.batch.domain.dto.WeeklyMetricsDto;
+import com.loopers.batch.domain.entity.WeeklyRankingMV;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class WeeklyRankingJobConfig {
+    
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    
+    @Value("${batch.chunk-size:1000}")
+    private int chunkSize;
+    
+    @Bean
+    public Job weeklyRankingJob(Step weeklyRankingStep) {
+        return new JobBuilder("weeklyRankingJob", jobRepository)
+                .listener(weeklyJobListener())
+                .start(weeklyRankingStep)
+                .build();
+    }
+    
+    @Bean  
+    public Step weeklyRankingStep(
+        ItemReader<WeeklyMetricsDto> weeklyMetricsReader,
+        ItemProcessor<WeeklyMetricsDto, WeeklyRankingMV> weeklyRankingProcessor,
+        ItemWriter<WeeklyRankingMV> weeklyRankingTopWriter
+    ) {
+        return new StepBuilder("weeklyRankingStep", jobRepository)
+                .<WeeklyMetricsDto, WeeklyRankingMV>chunk(chunkSize, transactionManager)
+                .reader(weeklyMetricsReader)
+                .processor(weeklyRankingProcessor)
+                .writer(weeklyRankingTopWriter)
+                .build();
+    }
+    
+    private JobExecutionListener weeklyJobListener() {
+        return new JobExecutionListener() {
+            @Override
+            public void beforeJob(JobExecution jobExecution) {
+                JobParameters params = jobExecution.getJobParameters();
+                String weekStartDate = params.getString("weekStartDate");
+                
+                log.info("=== 주간 랭킹 배치 시작 ===");
+                log.info("주 시작일: {}", weekStartDate);
+                log.info("청크 크기: {}", chunkSize);
+            }
+            
+            @Override
+            public void afterJob(JobExecution jobExecution) {
+                long executionTime = java.time.Duration.between(
+                    jobExecution.getStartTime(),
+                    jobExecution.getEndTime()
+                ).toSeconds();
+                
+                log.info("=== 주간 랭킹 배치 완료 ===");
+                log.info("실행 시간: {}초", executionTime);
+                log.info("최종 상태: {}", jobExecution.getStatus());
+            }
+        };
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/domain/dto/DailyMetricsDto.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/domain/dto/DailyMetricsDto.java
@@ -1,0 +1,53 @@
+package com.loopers.batch.domain.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * event_metrics에서 일별로 집계한 데이터 전송 객체
+ */
+public record DailyMetricsDto(
+    Long productId,
+    LocalDate statDate,
+    Long likeCount,
+    Long orderCount, 
+    Long viewCount
+) {
+    
+    public DailyMetricsDto {
+        if (productId == null || productId <= 0) {
+            throw new IllegalArgumentException("상품 ID는 양수여야 합니다");
+        }
+        if (statDate == null) {
+            throw new IllegalArgumentException("통계 날짜는 필수입니다");
+        }
+        if (likeCount == null || likeCount < 0) likeCount = 0L;
+        if (orderCount == null || orderCount < 0) orderCount = 0L;
+        if (viewCount == null || viewCount < 0) viewCount = 0L;
+    }
+    
+    /**
+     * 활동이 있는 상품인지 확인
+     */
+    public boolean hasActivity() {
+        return likeCount + orderCount + viewCount > 0;
+    }
+    
+    /**
+     * 총 활동 수
+     */
+    public long getTotalActivity() {
+        return likeCount + orderCount + viewCount;
+    }
+    
+    /**
+     * 가중치를 적용한 점수 계산
+     */
+    public BigDecimal calculateScore(double likeWeight, double orderWeight, double viewWeight) {
+        BigDecimal score = BigDecimal.valueOf(likeCount * likeWeight)
+            .add(BigDecimal.valueOf(orderCount * orderWeight))
+            .add(BigDecimal.valueOf(viewCount * viewWeight));
+        
+        return score.max(BigDecimal.ZERO);
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/domain/dto/MonthlyMetricsDto.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/domain/dto/MonthlyMetricsDto.java
@@ -1,0 +1,19 @@
+package com.loopers.batch.domain.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class MonthlyMetricsDto {
+    private Long productId;
+    private LocalDate targetDate;
+    private LocalDate periodStartDate;
+    private LocalDate periodEndDate;
+    private Long viewCount;
+    private Long likeCount;
+    private Long orderCount;
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/domain/dto/WeeklyMetricsDto.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/domain/dto/WeeklyMetricsDto.java
@@ -1,0 +1,37 @@
+package com.loopers.batch.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDate;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class WeeklyMetricsDto {
+    
+
+    private Long productId;
+    
+
+    private LocalDate targetDate;
+    
+
+    private LocalDate periodStartDate;
+    
+
+    private LocalDate periodEndDate;
+    
+
+    private Long viewCount;
+    
+
+    private Long likeCount;
+    
+
+    private Long orderCount;
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/DailyRankingMV.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/DailyRankingMV.java
@@ -1,0 +1,48 @@
+package com.loopers.batch.domain.entity;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "mv_product_rank_daily",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"product_id", "stat_date"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyRankingMV extends BaseEntity {
+    
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+    
+    @Column(name = "stat_date", nullable = false)
+    private LocalDate statDate;
+    
+    @Column(name = "like_count", nullable = false)
+    private Integer likeCount = 0;
+    
+    @Column(name = "order_count", nullable = false)
+    private Integer orderCount = 0;
+    
+    @Column(name = "view_count", nullable = false)
+    private Integer viewCount = 0;
+    
+    @Column(name = "score", nullable = false, precision = 18, scale = 6)
+    private BigDecimal score;
+    
+    @Builder
+    public DailyRankingMV(Long productId, LocalDate statDate, 
+                         Integer likeCount, Integer orderCount, Integer viewCount, BigDecimal score) {
+        this.productId = productId;
+        this.statDate = statDate;
+        this.likeCount = likeCount != null ? likeCount : 0;
+        this.orderCount = orderCount != null ? orderCount : 0;
+        this.viewCount = viewCount != null ? viewCount : 0;
+        this.score = score != null ? score : BigDecimal.ZERO;
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/MonthlyRankingMV.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/MonthlyRankingMV.java
@@ -2,52 +2,83 @@ package com.loopers.batch.domain.entity;
 
 import com.loopers.domain.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
 
 @Entity
-@Table(name = "mv_product_rank_monthly",
-       uniqueConstraints = @UniqueConstraint(columnNames = {"`year_month`", "product_id"}))
+@Table(
+    name = "mv_product_rank_monthly",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_monthly_product_target", columnNames = {"product_id", "target_date"})
+    },
+    indexes = {
+        @Index(name = "idx_monthly_target_score", columnList = "target_date, ranking_score DESC"),
+        @Index(name = "idx_monthly_product_target", columnList = "product_id, target_date")
+    }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MonthlyRankingMV extends BaseEntity {
-    
-    @Column(name = "`year_month`", nullable = false, length = 6)
-    private String yearMonth;
-    
+
+    // 테이블엔 있을 수 있으나 앱에서 세팅 안 함
+    @Column(name = "published_at", insertable = false, updatable = false)
+    private ZonedDateTime publishedAt;
+
     @Column(name = "product_id", nullable = false)
     private Long productId;
-    
-    @Column(name = "like_count", nullable = false)
-    private Integer likeCount = 0;
-    
-    @Column(name = "order_count", nullable = false)
-    private Integer orderCount = 0;
-    
+
+    @Column(name = "target_date", nullable = false)
+    private LocalDate targetDate;
+
+    @Column(name = "period_start_date", nullable = false)
+    private LocalDate periodStartDate;
+
+    @Column(name = "period_end_date", nullable = false)
+    private LocalDate periodEndDate;
+
     @Column(name = "view_count", nullable = false)
-    private Integer viewCount = 0;
-    
-    @Column(name = "score", nullable = false, precision = 18, scale = 6)
-    private BigDecimal score;
-    
-    @Column(name = "rank_no", nullable = false)
+    private Long viewCount = 0L;
+
+    @Column(name = "like_count", nullable = false)
+    private Long likeCount = 0L;
+
+    @Column(name = "order_count", nullable = false)
+    private Long orderCount = 0L;
+
+    @Column(name = "ranking_score", nullable = false, precision = 10, scale = 4)
+    private BigDecimal rankingScore = BigDecimal.ZERO;
+
+    // 주간에서 삽질했던 reflection 제거: 그냥 필드로 둔다
+    @Column(name = "rank_no")
     private Integer rankNo;
 
-    
     @Builder
-    public MonthlyRankingMV(String yearMonth, Long productId, Integer likeCount, Integer orderCount, 
-                           Integer viewCount, BigDecimal score, Integer rankNo) {
-        this.yearMonth = yearMonth;
+    public MonthlyRankingMV(
+        Long productId,
+        LocalDate targetDate,
+        LocalDate periodStartDate,
+        LocalDate periodEndDate,
+        Long viewCount,
+        Long likeCount,
+        Long orderCount,
+        BigDecimal rankingScore,
+        Integer rankNo
+    ) {
         this.productId = productId;
-        this.likeCount = likeCount != null ? likeCount : 0;
-        this.orderCount = orderCount != null ? orderCount : 0;
-        this.viewCount = viewCount != null ? viewCount : 0;
-        this.score = score != null ? score : BigDecimal.ZERO;
+        this.targetDate = targetDate;
+        this.periodStartDate = periodStartDate;
+        this.periodEndDate = periodEndDate;
+        this.viewCount = viewCount;
+        this.likeCount = likeCount;
+        this.orderCount = orderCount;
+        this.rankingScore = rankingScore;
+        this.rankNo = rankNo;
+    }
+
+    public void setRankNo(Integer rankNo) {
         this.rankNo = rankNo;
     }
 }

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/MonthlyRankingMV.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/MonthlyRankingMV.java
@@ -12,12 +12,12 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "mv_product_rank_monthly",
-       uniqueConstraints = @UniqueConstraint(columnNames = {"year_month", "product_id"}))
+       uniqueConstraints = @UniqueConstraint(columnNames = {"`year_month`", "product_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MonthlyRankingMV extends BaseEntity {
     
-    @Column(name = "year_month", nullable = false, length = 6)
+    @Column(name = "`year_month`", nullable = false, length = 6)
     private String yearMonth;
     
     @Column(name = "product_id", nullable = false)

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/MonthlyRankingMV.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/MonthlyRankingMV.java
@@ -1,0 +1,56 @@
+package com.loopers.batch.domain.entity;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mv_product_rank_monthly",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"year_month", "product_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MonthlyRankingMV extends BaseEntity {
+    
+    @Column(name = "year_month", nullable = false, length = 6)
+    private String yearMonth;
+    
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+    
+    @Column(name = "like_count", nullable = false)
+    private Integer likeCount = 0;
+    
+    @Column(name = "order_count", nullable = false)
+    private Integer orderCount = 0;
+    
+    @Column(name = "view_count", nullable = false)
+    private Integer viewCount = 0;
+    
+    @Column(name = "score", nullable = false, precision = 18, scale = 6)
+    private BigDecimal score;
+    
+    @Column(name = "rank_no", nullable = false)
+    private Integer rankNo;
+    
+    @Column(name = "published_at", nullable = false)
+    private LocalDateTime publishedAt;
+    
+    @Builder
+    public MonthlyRankingMV(String yearMonth, Long productId, Integer likeCount, Integer orderCount, 
+                           Integer viewCount, BigDecimal score, Integer rankNo, LocalDateTime publishedAt) {
+        this.yearMonth = yearMonth;
+        this.productId = productId;
+        this.likeCount = likeCount != null ? likeCount : 0;
+        this.orderCount = orderCount != null ? orderCount : 0;
+        this.viewCount = viewCount != null ? viewCount : 0;
+        this.score = score != null ? score : BigDecimal.ZERO;
+        this.rankNo = rankNo;
+        this.publishedAt = publishedAt != null ? publishedAt : LocalDateTime.now();
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/MonthlyRankingMV.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/MonthlyRankingMV.java
@@ -37,13 +37,11 @@ public class MonthlyRankingMV extends BaseEntity {
     
     @Column(name = "rank_no", nullable = false)
     private Integer rankNo;
-    
-    @Column(name = "published_at", nullable = false)
-    private LocalDateTime publishedAt;
+
     
     @Builder
     public MonthlyRankingMV(String yearMonth, Long productId, Integer likeCount, Integer orderCount, 
-                           Integer viewCount, BigDecimal score, Integer rankNo, LocalDateTime publishedAt) {
+                           Integer viewCount, BigDecimal score, Integer rankNo) {
         this.yearMonth = yearMonth;
         this.productId = productId;
         this.likeCount = likeCount != null ? likeCount : 0;
@@ -51,6 +49,5 @@ public class MonthlyRankingMV extends BaseEntity {
         this.viewCount = viewCount != null ? viewCount : 0;
         this.score = score != null ? score : BigDecimal.ZERO;
         this.rankNo = rankNo;
-        this.publishedAt = publishedAt != null ? publishedAt : LocalDateTime.now();
     }
 }

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/WeeklyRankingMV.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/WeeklyRankingMV.java
@@ -8,49 +8,72 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
 
+/**
+ * 주간 상품 랭킹 집계 테이블
+ */
 @Entity
 @Table(name = "mv_product_rank_weekly",
-       uniqueConstraints = @UniqueConstraint(columnNames = {"year_week", "product_id"}))
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_product_target", columnNames = {"product_id", "target_date"})
+    },
+    indexes = {
+        @Index(name = "idx_target_score", columnList = "target_date, ranking_score DESC"),
+        @Index(name = "idx_product_target", columnList = "product_id, target_date")
+    }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WeeklyRankingMV extends BaseEntity {
-    
-    @Column(name = "year_week", nullable = false, length = 8)
-    private String yearWeek;
-    
+
+    @Column(name = "published_at", insertable = false, updatable = false)
+    private ZonedDateTime publishedAt;
+
     @Column(name = "product_id", nullable = false)
     private Long productId;
-    
-    @Column(name = "like_count", nullable = false)
-    private Integer likeCount = 0;
-    
-    @Column(name = "order_count", nullable = false)
-    private Integer orderCount = 0;
-    
+
+    @Column(name = "target_date", nullable = false)
+    private LocalDate targetDate;
+
+    @Column(name = "period_start_date", nullable = false)
+    private LocalDate periodStartDate;
+
+    @Column(name = "period_end_date", nullable = false)
+    private LocalDate periodEndDate;
+
     @Column(name = "view_count", nullable = false)
-    private Integer viewCount = 0;
-    
-    @Column(name = "score", nullable = false, precision = 18, scale = 6)
-    private BigDecimal score;
-    
+    private Long viewCount = 0L;
+
+    @Column(name = "like_count", nullable = false)
+    private Long likeCount = 0L;
+
+    @Column(name = "order_count", nullable = false)
+    private Long orderCount = 0L;
+
+    @Column(name = "ranking_score", nullable = false, precision = 10, scale = 4)
+    private BigDecimal rankingScore = BigDecimal.ZERO;
+
     @Column(name = "rank_no", nullable = false)
     private Integer rankNo;
-    
-    @Column(name = "published_at", nullable = false)
-    private LocalDateTime publishedAt;
-    
+
+    // 순위 세팅용(리플렉션 말고 메서드로)
+    public void assignRank(int rank) {
+        this.rankNo = rank;
+    }
+
     @Builder
-    public WeeklyRankingMV(String yearWeek, Long productId, Integer likeCount, Integer orderCount, 
-                          Integer viewCount, BigDecimal score, Integer rankNo, LocalDateTime publishedAt) {
-        this.yearWeek = yearWeek;
+    public WeeklyRankingMV(Long productId, LocalDate targetDate, LocalDate periodStartDate,
+        LocalDate periodEndDate, Long viewCount, Long likeCount,
+        Long orderCount, BigDecimal rankingScore) {
         this.productId = productId;
-        this.likeCount = likeCount != null ? likeCount : 0;
-        this.orderCount = orderCount != null ? orderCount : 0;
-        this.viewCount = viewCount != null ? viewCount : 0;
-        this.score = score != null ? score : BigDecimal.ZERO;
-        this.rankNo = rankNo;
-        this.publishedAt = publishedAt != null ? publishedAt : LocalDateTime.now();
+        this.targetDate = targetDate;
+        this.periodStartDate = periodStartDate;
+        this.periodEndDate = periodEndDate;
+        this.viewCount = viewCount;
+        this.likeCount = likeCount;
+        this.orderCount = orderCount;
+        this.rankingScore = rankingScore;
     }
 }

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/WeeklyRankingMV.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/domain/entity/WeeklyRankingMV.java
@@ -1,0 +1,56 @@
+package com.loopers.batch.domain.entity;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mv_product_rank_weekly",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"year_week", "product_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WeeklyRankingMV extends BaseEntity {
+    
+    @Column(name = "year_week", nullable = false, length = 8)
+    private String yearWeek;
+    
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+    
+    @Column(name = "like_count", nullable = false)
+    private Integer likeCount = 0;
+    
+    @Column(name = "order_count", nullable = false)
+    private Integer orderCount = 0;
+    
+    @Column(name = "view_count", nullable = false)
+    private Integer viewCount = 0;
+    
+    @Column(name = "score", nullable = false, precision = 18, scale = 6)
+    private BigDecimal score;
+    
+    @Column(name = "rank_no", nullable = false)
+    private Integer rankNo;
+    
+    @Column(name = "published_at", nullable = false)
+    private LocalDateTime publishedAt;
+    
+    @Builder
+    public WeeklyRankingMV(String yearWeek, Long productId, Integer likeCount, Integer orderCount, 
+                          Integer viewCount, BigDecimal score, Integer rankNo, LocalDateTime publishedAt) {
+        this.yearWeek = yearWeek;
+        this.productId = productId;
+        this.likeCount = likeCount != null ? likeCount : 0;
+        this.orderCount = orderCount != null ? orderCount : 0;
+        this.viewCount = viewCount != null ? viewCount : 0;
+        this.score = score != null ? score : BigDecimal.ZERO;
+        this.rankNo = rankNo;
+        this.publishedAt = publishedAt != null ? publishedAt : LocalDateTime.now();
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/domain/service/RankingScoreCalculator.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/domain/service/RankingScoreCalculator.java
@@ -1,0 +1,56 @@
+package com.loopers.batch.domain.service;
+
+import com.loopers.batch.domain.dto.DailyMetricsDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+
+@Service
+@Slf4j
+public class RankingScoreCalculator {
+    
+    private final double likeWeight;
+    private final double orderWeight;
+    private final double viewWeight;
+    
+    public RankingScoreCalculator(
+        @Value("${ranking.weights.like:0.2}") double likeWeight,
+        @Value("${ranking.weights.order:0.7}") double orderWeight,
+        @Value("${ranking.weights.view:0.1}") double viewWeight
+    ) {
+        validateWeights(likeWeight, orderWeight, viewWeight);
+        this.likeWeight = likeWeight;
+        this.orderWeight = orderWeight;
+        this.viewWeight = viewWeight;
+        
+        log.info("랭킹 점수 계산기 초기화 - Like: {}, Order: {}, View: {}", 
+                likeWeight, orderWeight, viewWeight);
+    }
+    
+
+    public BigDecimal calculateScore(DailyMetricsDto metrics) {
+        if (!metrics.hasActivity()) {
+            return BigDecimal.ZERO;
+        }
+        
+        return metrics.calculateScore(likeWeight, orderWeight, viewWeight);
+    }
+    
+
+    private void validateWeights(double like, double order, double view) {
+        if (like < 0 || order < 0 || view < 0) {
+            throw new IllegalArgumentException("가중치는 음수일 수 없습니다");
+        }
+        
+        if (like + order + view == 0) {
+            throw new IllegalArgumentException("모든 가중치가 0일 수 없습니다");
+        }
+    }
+    
+    public double getLikeWeight() { return likeWeight; }
+    public double getOrderWeight() { return orderWeight; }
+    public double getViewWeight() { return viewWeight; }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/processor/DailyRankingProcessor.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/processor/DailyRankingProcessor.java
@@ -1,0 +1,54 @@
+package com.loopers.batch.job.processor;
+
+import com.loopers.batch.domain.dto.DailyMetricsDto;
+import com.loopers.batch.domain.entity.DailyRankingMV;
+import com.loopers.batch.domain.service.RankingScoreCalculator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+/**
+ * DailyMetricsDto를 DailyRankingMV 엔티티로 변환하는 Processor
+ * 
+ * 책임:
+ * - 메트릭 데이터를 엔티티로 변환
+ * - 점수 계산 로직 적용 (위임)
+ * - 비즈니스 규칙 적용 (활동 없는 상품 필터링)
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DailyRankingProcessor implements ItemProcessor<DailyMetricsDto, DailyRankingMV> {
+    
+    private final RankingScoreCalculator scoreCalculator;
+    
+    @Override
+    public DailyRankingMV process(DailyMetricsDto metrics) {
+        // 활동이 없는 상품 필터링
+        if (!metrics.hasActivity()) {
+            log.debug("상품 {} - 활동 없음, 건너뜀", metrics.productId());
+            return null;
+        }
+        
+        // 점수 계산 (책임 위임)
+        BigDecimal score = scoreCalculator.calculateScore(metrics);
+        
+        // 엔티티 생성
+        DailyRankingMV entity = DailyRankingMV.builder()
+            .productId(metrics.productId())
+            .statDate(metrics.statDate())
+            .likeCount(metrics.likeCount().intValue())
+            .orderCount(metrics.orderCount().intValue())
+            .viewCount(metrics.viewCount().intValue())
+            .score(score)
+            .build();
+        
+        log.debug("상품 {} 처리 완료 - 점수: {}, 활동: {}", 
+                 metrics.productId(), score, metrics.getTotalActivity());
+        
+        return entity;
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/processor/MonthlyRankingProcessor.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/processor/MonthlyRankingProcessor.java
@@ -1,0 +1,49 @@
+package com.loopers.batch.job.processor;
+
+import com.loopers.batch.domain.dto.DailyMetricsDto;
+import com.loopers.batch.domain.dto.MonthlyMetricsDto;
+import com.loopers.batch.domain.entity.MonthlyRankingMV;
+import com.loopers.batch.domain.service.RankingScoreCalculator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class MonthlyRankingProcessor implements ItemProcessor<MonthlyMetricsDto, MonthlyRankingMV> {
+
+    private final RankingScoreCalculator scoreCalculator;
+
+    @Override
+    public MonthlyRankingMV process(MonthlyMetricsDto item) {
+        BigDecimal score = scoreCalculator.calculateScore(
+            new DailyMetricsDto(
+                item.getProductId(),
+                item.getTargetDate(),
+                item.getLikeCount(),
+                item.getOrderCount(),
+                item.getViewCount()
+            )
+        );
+
+        log.debug("월간 랭킹 처리 - 상품ID: {}, 대상날짜: {}, 점수: {}",
+            item.getProductId(), item.getTargetDate(), score);
+
+        return MonthlyRankingMV.builder()
+            .productId(item.getProductId())
+            .targetDate(item.getTargetDate())
+            .periodStartDate(item.getPeriodStartDate())
+            .periodEndDate(item.getPeriodEndDate())
+            .viewCount(item.getViewCount())
+            .likeCount(item.getLikeCount())
+            .orderCount(item.getOrderCount())
+            .rankingScore(score)
+            .build();
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/processor/WeeklyRankingProcessor.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/processor/WeeklyRankingProcessor.java
@@ -1,0 +1,51 @@
+package com.loopers.batch.job.processor;
+
+import com.loopers.batch.domain.dto.DailyMetricsDto;
+import com.loopers.batch.domain.dto.WeeklyMetricsDto;
+import com.loopers.batch.domain.entity.WeeklyRankingMV;
+import com.loopers.batch.domain.service.RankingScoreCalculator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class WeeklyRankingProcessor implements ItemProcessor<WeeklyMetricsDto, WeeklyRankingMV> {
+    
+    private final RankingScoreCalculator scoreCalculator;
+    
+    @Override
+    public WeeklyRankingMV process(WeeklyMetricsDto item) throws Exception {
+        
+        // 주간 랭킹 점수 계산 (개별 메트릭 값으로 계산)
+        BigDecimal weeklyScore = scoreCalculator.calculateScore(
+            new DailyMetricsDto(
+                item.getProductId(),
+                item.getTargetDate(), 
+                item.getLikeCount(),
+                item.getOrderCount(),
+                item.getViewCount()
+            )
+        );
+        
+        log.debug("주간 랭킹 처리 - 상품ID: {}, 대상날짜: {}, 점수: {}", 
+                 item.getProductId(), item.getTargetDate(), weeklyScore);
+        
+        return WeeklyRankingMV.builder()
+                .productId(item.getProductId())
+                .targetDate(item.getTargetDate())
+                .periodStartDate(item.getPeriodStartDate())
+                .periodEndDate(item.getPeriodEndDate())
+                .viewCount(item.getViewCount())
+                .likeCount(item.getLikeCount())
+                .orderCount(item.getOrderCount())
+                .rankingScore(weeklyScore)
+                .build();
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/reader/EventMetricsCursorReader.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/reader/EventMetricsCursorReader.java
@@ -1,0 +1,89 @@
+package com.loopers.batch.job.reader;
+
+import com.loopers.batch.domain.dto.DailyMetricsDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
+import org.springframework.batch.item.database.builder.JdbcCursorItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+
+
+@Configuration
+@Slf4j
+public class EventMetricsCursorReader {
+    
+    private static final String DAILY_AGGREGATION_SQL = """
+        SELECT 
+            em.product_id,
+            em.metric_date,
+            SUM(CASE WHEN em.event_type = 'ProductLiked' THEN em.metric_value ELSE 0 END) as like_count,
+            SUM(CASE WHEN em.event_type = 'OrderCreated' THEN em.metric_value ELSE 0 END) as order_count,
+            SUM(CASE WHEN em.event_type = 'ProductViewed' THEN em.metric_value ELSE 0 END) as view_count
+        FROM event_metrics em
+        WHERE em.metric_date = ?
+          AND em.product_id IS NOT NULL
+        GROUP BY em.product_id, em.metric_date
+        HAVING (like_count + order_count + view_count) > 0
+        ORDER BY em.product_id ASC
+        """;
+    
+    @Bean
+    @StepScope
+    public JdbcCursorItemReader<DailyMetricsDto> dailyMetricsReader(
+        DataSource dataSource,
+        @Value("#{jobParameters['targetDate'] ?: '2025-09-11'}") String targetDate
+    ) {
+        log.info("일별 메트릭 Reader 초기화 - 대상 날짜: {}", targetDate);
+        
+        // null 체크 및 기본값 설정
+        final String finalTargetDate;
+        if (targetDate == null || targetDate.trim().isEmpty()) {
+            finalTargetDate = "2025-09-11"; // 테스트 데이터가 있는 날짜
+            log.warn("targetDate가 null이므로 기본값 사용: {}", finalTargetDate);
+        } else {
+            finalTargetDate = targetDate;
+        }
+        
+        LocalDate statDate = LocalDate.parse(finalTargetDate);
+        
+        return new JdbcCursorItemReaderBuilder<DailyMetricsDto>()
+            .name("dailyMetricsReader")
+            .dataSource(dataSource)
+            .sql(DAILY_AGGREGATION_SQL)
+            .preparedStatementSetter(ps -> ps.setString(1, finalTargetDate))
+            .rowMapper(new DailyMetricsRowMapper(statDate))
+            .build();
+    }
+    
+    /**
+     * ResultSet을 DailyMetricsDto로 변환하는 RowMapper
+     */
+    private static class DailyMetricsRowMapper implements RowMapper<DailyMetricsDto> {
+        
+        private final LocalDate statDate;
+        
+        public DailyMetricsRowMapper(LocalDate statDate) {
+            this.statDate = statDate;
+        }
+        
+        @Override
+        public DailyMetricsDto mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new DailyMetricsDto(
+                rs.getLong("product_id"),
+                statDate,
+                rs.getLong("like_count"),
+                rs.getLong("order_count"),
+                rs.getLong("view_count")
+            );
+        }
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/reader/MonthlyMetricsCursorReader.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/reader/MonthlyMetricsCursorReader.java
@@ -1,0 +1,86 @@
+package com.loopers.batch.job.reader;
+
+import com.loopers.batch.domain.dto.MonthlyMetricsDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
+import org.springframework.batch.item.database.builder.JdbcCursorItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+
+@Configuration
+@Slf4j
+public class MonthlyMetricsCursorReader {
+
+    private static final String MONTHLY_AGGREGATION_SQL = """
+        SELECT 
+            d.product_id,
+            SUM(d.view_count) AS view_count,
+            SUM(d.like_count) AS like_count,
+            SUM(d.order_count) AS order_count
+        FROM mv_product_rank_daily d
+        WHERE d.stat_date >= ? AND d.stat_date <= ?
+        GROUP BY d.product_id
+        HAVING (view_count + like_count + order_count) > 0
+        ORDER BY d.product_id ASC
+        """;
+
+    @Bean
+    @StepScope
+    public JdbcCursorItemReader<MonthlyMetricsDto> monthlyMetricsReader(
+        DataSource dataSource,
+        @Value("#{jobParameters['targetDate'] ?: '2025-09-30'}") String targetDate
+    ) {
+        final String finalTarget = (targetDate == null || targetDate.isBlank()) ? "2025-09-30" : targetDate;
+
+        LocalDate target = LocalDate.parse(finalTarget);
+        LocalDate startDate = target.withDayOfMonth(1);
+        LocalDate endDate = target.withDayOfMonth(target.lengthOfMonth());
+
+        log.info("월간 메트릭 Reader 초기화 - 대상 날짜: {}, 범위: {} ~ {} ({}일)",
+            finalTarget, startDate, endDate, endDate.lengthOfMonth());
+
+        return new JdbcCursorItemReaderBuilder<MonthlyMetricsDto>()
+            .name("monthlyMetricsReader")
+            .dataSource(dataSource)
+            .sql(MONTHLY_AGGREGATION_SQL)
+            .preparedStatementSetter(ps -> {
+                ps.setDate(1, java.sql.Date.valueOf(startDate));
+                ps.setDate(2, java.sql.Date.valueOf(endDate));
+            })
+            .rowMapper(new MonthlyRowMapper(target, startDate, endDate))
+            .build();
+    }
+
+    private static class MonthlyRowMapper implements RowMapper<MonthlyMetricsDto> {
+        private final LocalDate targetDate;
+        private final LocalDate periodStartDate;
+        private final LocalDate periodEndDate;
+
+        public MonthlyRowMapper(LocalDate targetDate, LocalDate periodStartDate, LocalDate periodEndDate) {
+            this.targetDate = targetDate;
+            this.periodStartDate = periodStartDate;
+            this.periodEndDate = periodEndDate;
+        }
+
+        @Override
+        public MonthlyMetricsDto mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new MonthlyMetricsDto(
+                rs.getLong("product_id"),
+                targetDate,
+                periodStartDate,
+                periodEndDate,
+                rs.getLong("view_count"),
+                rs.getLong("like_count"),
+                rs.getLong("order_count")
+            );
+        }
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/reader/WeeklyMetricsCursorReader.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/reader/WeeklyMetricsCursorReader.java
@@ -1,0 +1,98 @@
+package com.loopers.batch.job.reader;
+
+import com.loopers.batch.domain.dto.WeeklyMetricsDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
+import org.springframework.batch.item.database.builder.JdbcCursorItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.RowMapper;
+
+import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+
+
+@Configuration
+@Slf4j
+public class WeeklyMetricsCursorReader {
+    
+    private static final String WEEKLY_AGGREGATION_SQL = """
+        SELECT 
+            d.product_id,
+            SUM(d.view_count) as view_count,
+            SUM(d.like_count) as like_count,
+            SUM(d.order_count) as order_count
+        FROM mv_product_rank_daily d
+        WHERE d.stat_date >= ? AND d.stat_date <= ?
+        GROUP BY d.product_id
+        HAVING (view_count + like_count + order_count) > 0
+        ORDER BY d.product_id ASC
+        """;
+    
+    @Bean
+    @StepScope
+    public JdbcCursorItemReader<WeeklyMetricsDto> weeklyMetricsReader(
+        DataSource dataSource,
+        @Value("#{jobParameters['targetDate'] ?: '2025-09-18'}") String targetDate
+    ) {
+        log.info("주간 메트릭 Reader 초기화 - 대상 날짜: {}", targetDate);
+        
+        // null 체크 및 기본값 설정
+        final String finalTargetDate;
+        if (targetDate == null || targetDate.trim().isEmpty()) {
+            finalTargetDate = "2025-09-18"; // 기본값
+            log.warn("targetDate가 null이므로 기본값 사용: {}", finalTargetDate);
+        } else {
+            finalTargetDate = targetDate;
+        }
+        
+        LocalDate endDate = LocalDate.parse(finalTargetDate);  
+        LocalDate startDate = endDate.minusDays(6); // 7일간 (오늘 포함)
+        
+        log.info("주간 슬라이딩 윈도우: {} ~ {} ({}일간)", startDate, endDate, 7);
+        
+        return new JdbcCursorItemReaderBuilder<WeeklyMetricsDto>()
+            .name("weeklyMetricsReader")
+            .dataSource(dataSource)
+            .sql(WEEKLY_AGGREGATION_SQL)
+            .preparedStatementSetter(ps -> {
+                ps.setDate(1, java.sql.Date.valueOf(startDate));
+                ps.setDate(2, java.sql.Date.valueOf(endDate));
+            })
+            .rowMapper(new WeeklyMetricsRowMapper(endDate, startDate, endDate))
+            .build();
+    }
+    
+
+    private static class WeeklyMetricsRowMapper implements RowMapper<WeeklyMetricsDto> {
+        
+        private final LocalDate targetDate;
+        private final LocalDate periodStartDate;
+        private final LocalDate periodEndDate;
+        
+        public WeeklyMetricsRowMapper(LocalDate targetDate, LocalDate periodStartDate, LocalDate periodEndDate) {
+            this.targetDate = targetDate;
+            this.periodStartDate = periodStartDate;
+            this.periodEndDate = periodEndDate;
+        }
+        
+        @Override
+        public WeeklyMetricsDto mapRow(ResultSet rs, int rowNum) throws SQLException {
+            return new WeeklyMetricsDto(
+                rs.getLong("product_id"),
+                targetDate,
+                periodStartDate,
+                periodEndDate,
+                rs.getLong("view_count"),
+                rs.getLong("like_count"),
+                rs.getLong("order_count")
+            );
+        }
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/DailyRankingWriter.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/DailyRankingWriter.java
@@ -1,0 +1,70 @@
+package com.loopers.batch.job.writer;
+
+import com.loopers.batch.domain.entity.DailyRankingMV;
+import com.loopers.batch.repository.DailyRankingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class DailyRankingWriter implements ItemWriter<DailyRankingMV>, StepExecutionListener {
+    
+    private final DailyRankingRepository repository;
+    private final AtomicInteger processedCount = new AtomicInteger(0);
+    
+    @Value("#{jobParameters['targetDate']}")
+    private String targetDate;
+    
+    @Override
+    @Transactional
+    public void beforeStep(StepExecution stepExecution) {
+        LocalDate statDate = LocalDate.parse(targetDate);
+        
+
+        repository.deleteByStatDate(statDate);
+        log.info("기존 데이터 삭제 완료 - 날짜: {}", statDate);
+        
+        processedCount.set(0);
+        log.info("일별 랭킹 저장 시작 - 대상 날짜: {}", statDate);
+    }
+    
+    @Override
+    @Transactional
+    public void write(Chunk<? extends DailyRankingMV> chunk) {
+        if (chunk.isEmpty()) {
+            return;
+        }
+        
+
+        repository.saveAll(chunk.getItems());
+        
+        int currentCount = processedCount.addAndGet(chunk.size());
+        log.debug("일별 랭킹 저장 진행 - 현재 {}건 처리됨", currentCount);
+    }
+    
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        int totalProcessed = processedCount.get();
+        log.info("일별 랭킹 저장 완료 - 총 처리 건수: {}", totalProcessed);
+        
+
+        stepExecution.getExecutionContext().putInt("processedCount", totalProcessed);
+        
+        return ExitStatus.COMPLETED;
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/MonthlyRankingTopWriter.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/MonthlyRankingTopWriter.java
@@ -1,0 +1,89 @@
+package com.loopers.batch.job.writer;
+
+import com.loopers.batch.domain.entity.MonthlyRankingMV;
+import com.loopers.batch.repository.MonthlyRankingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.*;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class MonthlyRankingTopWriter implements ItemWriter<MonthlyRankingMV>, StepExecutionListener {
+
+    private final MonthlyRankingRepository repository;
+
+    private final PriorityQueue<MonthlyRankingMV> topProducts = new PriorityQueue<>(
+        Comparator.comparing(MonthlyRankingMV::getRankingScore)
+    );
+
+    @Value("#{jobParameters['targetDate']}")
+    private String targetDate;
+
+    private static final int TOP_N = 100;
+
+    @Override
+    @Transactional
+    public void beforeStep(StepExecution stepExecution) {
+        LocalDate date = LocalDate.parse(targetDate);
+        repository.deleteByTargetDate(date);
+        log.info("월간 Top {} 기존 데이터 삭제 완료 - 날짜: {}", TOP_N, date);
+        topProducts.clear();
+        log.info("월간 Top {} 랭킹 수집 시작 - 대상 날짜: {}", TOP_N, date);
+    }
+
+    @Override
+    public void write(Chunk<? extends MonthlyRankingMV> chunk) {
+        for (MonthlyRankingMV item : chunk) {
+            if (topProducts.size() < TOP_N) {
+                topProducts.offer(item);
+            } else {
+                MonthlyRankingMV lowest = topProducts.peek();
+                if (lowest != null && item.getRankingScore().compareTo(lowest.getRankingScore()) > 0) {
+                    topProducts.poll();
+                    topProducts.offer(item);
+                }
+            }
+        }
+        log.debug("월간 Top 후보 수집 - PQ 크기: {}", topProducts.size());
+    }
+
+    @Override
+    @Transactional
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        List<MonthlyRankingMV> finalTop = new ArrayList<>(topProducts);
+        finalTop.sort(Comparator.comparing(MonthlyRankingMV::getRankingScore).reversed());
+
+        // rank_no 채움 (reflection 금지)
+        int rank = 1;
+        for (MonthlyRankingMV mv : finalTop) {
+            mv.setRankNo(rank++);
+        }
+
+        if (!finalTop.isEmpty()) {
+            repository.saveAll(finalTop);
+        }
+
+        int saved = finalTop.size();
+        log.info("월간 Top {} 저장 완료 - 저장 건수: {}", TOP_N, saved);
+        if (saved > 0) {
+            BigDecimal topScore = finalTop.get(0).getRankingScore();
+            BigDecimal bottomScore = finalTop.get(saved - 1).getRankingScore();
+            log.info("월간 점수 범위: {} (1위) ~ {} ({}위)", topScore, bottomScore, saved);
+        }
+
+        stepExecution.getExecutionContext().putInt("monthlyTopSaved", saved);
+        return ExitStatus.COMPLETED;
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/MonthlyRankingWriter.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/MonthlyRankingWriter.java
@@ -1,0 +1,56 @@
+package com.loopers.batch.job.writer;
+
+import com.loopers.batch.domain.entity.MonthlyRankingMV;
+import com.loopers.batch.repository.MonthlyRankingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class MonthlyRankingWriter implements ItemWriter<MonthlyRankingMV>, StepExecutionListener {
+
+    private final MonthlyRankingRepository repository;
+    private final AtomicInteger processedCount = new AtomicInteger(0);
+
+    @Value("#{jobParameters['targetDate']}")
+    private String targetDate;
+
+    @Override
+    @Transactional
+    public void beforeStep(StepExecution stepExecution) {
+        LocalDate date = LocalDate.parse(targetDate);
+        repository.deleteByTargetDate(date);
+        log.info("월간 기존 데이터 삭제 완료 - 날짜: {}", date);
+        processedCount.set(0);
+        log.info("월간 랭킹 저장 시작 - 대상 날짜: {}", date);
+    }
+
+    @Override
+    @Transactional
+    public void write(Chunk<? extends MonthlyRankingMV> chunk) {
+        if (chunk.isEmpty()) return;
+        repository.saveAll(chunk.getItems());
+        int current = processedCount.addAndGet(chunk.size());
+        log.debug("월간 랭킹 저장 진행 - 현재 {}건 처리", current);
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        int total = processedCount.get();
+        log.info("월간 랭킹 저장 완료 - 총 처리 건수: {}", total);
+        stepExecution.getExecutionContext().putInt("monthlyProcessedCount", total);
+        return ExitStatus.COMPLETED;
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/MonthlyRankingWriter.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/MonthlyRankingWriter.java
@@ -25,16 +25,18 @@ public class MonthlyRankingWriter implements ItemWriter<MonthlyRankingMV>, StepE
     private final AtomicInteger processedCount = new AtomicInteger(0);
 
     @Value("#{jobParameters['targetDate']}")
-    private String targetDate;
+    private String targetDateParam;
+
+    private LocalDate snapshotDate;
 
     @Override
     @Transactional
     public void beforeStep(StepExecution stepExecution) {
-        LocalDate date = LocalDate.parse(targetDate);
-        repository.deleteByTargetDate(date);
-        log.info("월간 기존 데이터 삭제 완료 - 날짜: {}", date);
+        this.snapshotDate = LocalDate.parse(targetDateParam);
+        repository.deleteByTargetDate(snapshotDate);
+        log.info("월간 기존 데이터 삭제 완료 - 날짜: {}", snapshotDate);
         processedCount.set(0);
-        log.info("월간 랭킹 저장 시작 - 대상 날짜: {}", date);
+        log.info("월간 랭킹 저장 시작 - 대상 날짜: {}", snapshotDate);
     }
 
     @Override

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/WeeklyRankingTopWriter.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/WeeklyRankingTopWriter.java
@@ -1,0 +1,119 @@
+package com.loopers.batch.job.writer;
+
+import com.loopers.batch.domain.entity.WeeklyRankingMV;
+import com.loopers.batch.repository.WeeklyRankingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
+
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class WeeklyRankingTopWriter implements ItemWriter<WeeklyRankingMV>, StepExecutionListener {
+    
+    private final WeeklyRankingRepository repository;
+    
+    // 최소 힙: 가장 낮은 점수가 top에 위치 (100개 넘으면 제거)
+    private final PriorityQueue<WeeklyRankingMV> topProducts = new PriorityQueue<>(
+        Comparator.comparing(WeeklyRankingMV::getRankingScore)
+    );
+    
+    @Value("#{jobParameters['targetDate']}")
+    private String targetDate;
+    
+    private static final int TOP_N = 100;
+    
+    @Override
+    @Transactional
+    public void beforeStep(StepExecution stepExecution) {
+        LocalDate date = LocalDate.parse(targetDate);
+        
+
+        repository.deleteByTargetDate(date);
+        log.info("기존 데이터 삭제 완료 - 날짜: {}", date);
+        
+        topProducts.clear();
+        log.info("주간 Top {} 랭킹 수집 시작 - 대상 날짜: {}", TOP_N, date);
+    }
+    
+    @Override
+    public void write(Chunk<? extends WeeklyRankingMV> chunk) {
+        for (WeeklyRankingMV item : chunk) {
+            
+            if (topProducts.size() < TOP_N) {
+                // 아직 100개 미만이면 추가
+                topProducts.offer(item);
+            } else {
+                // 100개 찼으면 최소값과 비교
+                WeeklyRankingMV lowest = topProducts.peek();
+                if (lowest != null && item.getRankingScore().compareTo(lowest.getRankingScore()) > 0) {
+                    topProducts.poll(); // 최소값 제거
+                    topProducts.offer(item); // 새 값 추가
+                }
+            }
+        }
+        
+        log.debug("현재 Top 후보 수집 중 - PQ 크기: {}", topProducts.size());
+    }
+
+
+    @Override
+    @Transactional
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        List<WeeklyRankingMV> finalTop100 = new ArrayList<>(topProducts);
+
+
+        finalTop100.sort(Comparator
+            .comparing(WeeklyRankingMV::getRankingScore).reversed()
+            .thenComparing(WeeklyRankingMV::getOrderCount, Comparator.reverseOrder())
+            .thenComparing(WeeklyRankingMV::getLikeCount, Comparator.reverseOrder())
+            .thenComparing(WeeklyRankingMV::getViewCount, Comparator.reverseOrder())
+            .thenComparing(WeeklyRankingMV::getProductId)
+        );
+
+
+        int rank = 0;
+        BigDecimal prevScore = null;
+        for (WeeklyRankingMV cur : finalTop100) {
+            if (prevScore == null || cur.getRankingScore().compareTo(prevScore) != 0) {
+                rank++;
+                prevScore = cur.getRankingScore();
+            }
+            cur.assignRank(rank);
+        }
+
+
+        if (!finalTop100.isEmpty()) {
+            repository.saveAll(finalTop100);
+        }
+
+        log.info("주간 Top {} 랭킹 저장 완료 - 저장 건수: {}", TOP_N, finalTop100.size());
+        if (!finalTop100.isEmpty()) {
+            BigDecimal topScore = finalTop100.get(0).getRankingScore();
+            BigDecimal bottomScore = finalTop100.get(finalTop100.size() - 1).getRankingScore();
+            log.info("점수 범위: {} (1위) ~ {} ({}위)", topScore, bottomScore, finalTop100.size());
+        }
+
+        stepExecution.getExecutionContext().putInt("topRankingSaved", finalTop100.size());
+        return ExitStatus.COMPLETED;
+    }
+
+
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/WeeklyRankingTopWriter.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/WeeklyRankingTopWriter.java
@@ -43,9 +43,17 @@ public class WeeklyRankingTopWriter implements ItemWriter<WeeklyRankingMV>, Step
     @Override
     @Transactional
     public void beforeStep(StepExecution stepExecution) {
-        LocalDate date = LocalDate.parse(targetDate);
+        if (targetDate == null || targetDate.isBlank()) {
+            throw new IllegalArgumentException("jobParameters['targetDate']는 필수입니다");
+        }
         
-
+        LocalDate date;
+        try {
+            date = LocalDate.parse(targetDate);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("targetDate 형식이 잘못되었습니다(예: 2025-09-18): " + targetDate, e);
+        }
+        
         repository.deleteByTargetDate(date);
         log.info("기존 데이터 삭제 완료 - 날짜: {}", date);
         

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/WeeklyRankingWriter.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/job/writer/WeeklyRankingWriter.java
@@ -1,0 +1,69 @@
+package com.loopers.batch.job.writer;
+
+import com.loopers.batch.domain.entity.WeeklyRankingMV;
+import com.loopers.batch.repository.WeeklyRankingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+@Slf4j
+public class WeeklyRankingWriter implements ItemWriter<WeeklyRankingMV>, StepExecutionListener {
+    
+    private final WeeklyRankingRepository repository;
+    private final AtomicInteger processedCount = new AtomicInteger(0);
+    
+    @Value("#{jobParameters['targetDate']}")
+    private String targetDate;
+    
+    @Override
+    @Transactional
+    public void beforeStep(StepExecution stepExecution) {
+        LocalDate date = LocalDate.parse(targetDate);
+        
+        // 기존 데이터 삭제 (멱등성 보장)
+        repository.deleteByTargetDate(date);
+        log.info("기존 데이터 삭제 완료 - 날짜: {}", date);
+        
+        processedCount.set(0);
+        log.info("주간 랭킹 저장 시작 - 대상 날짜: {}", date);
+    }
+    
+    @Override
+    @Transactional
+    public void write(Chunk<? extends WeeklyRankingMV> chunk) {
+        if (chunk.isEmpty()) {
+            return;
+        }
+        
+        // 배치 저장
+        repository.saveAll(chunk.getItems());
+        
+        int currentCount = processedCount.addAndGet(chunk.size());
+        log.debug("주간 랭킹 저장 진행 - 현재 {}건 처리됨", currentCount);
+    }
+    
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        int totalProcessed = processedCount.get();
+        log.info("주간 랭킹 저장 완료 - 총 처리 건수: {}", totalProcessed);
+
+        stepExecution.getExecutionContext().putInt("processedCount", totalProcessed);
+        
+        return ExitStatus.COMPLETED;
+    }
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/repository/DailyRankingRepository.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/repository/DailyRankingRepository.java
@@ -1,0 +1,22 @@
+package com.loopers.batch.repository;
+
+import com.loopers.batch.domain.entity.DailyRankingMV;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface DailyRankingRepository extends JpaRepository<DailyRankingMV, Long> {
+    
+    /**
+     * 특정 날짜 범위의 일별 랭킹 조회 (배치에서만 사용)
+     */
+    List<DailyRankingMV> findByStatDateBetweenOrderByProductId(LocalDate startDate, LocalDate endDate);
+    
+    /**
+     * 특정 날짜의 데이터 삭제 (재실행용)
+     */
+    void deleteByStatDate(LocalDate statDate);
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/repository/MonthlyRankingRepository.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/repository/MonthlyRankingRepository.java
@@ -1,0 +1,21 @@
+package com.loopers.batch.repository;
+
+import com.loopers.batch.domain.entity.MonthlyRankingMV;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MonthlyRankingRepository extends JpaRepository<MonthlyRankingMV, Long> {
+    
+    /**
+     * 특정 년월의 랭킹 조회 (순위 순)
+     */
+    List<MonthlyRankingMV> findByYearMonthOrderByRankNo(String yearMonth);
+    
+    /**
+     * 특정 년월의 데이터 삭제 (재실행용)
+     */
+    void deleteByYearMonth(String yearMonth);
+}

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/repository/MonthlyRankingRepository.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/repository/MonthlyRankingRepository.java
@@ -1,21 +1,20 @@
 package com.loopers.batch.repository;
 
 import com.loopers.batch.domain.entity.MonthlyRankingMV;
+import java.time.LocalDate;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface MonthlyRankingRepository extends JpaRepository<MonthlyRankingMV, Long> {
-    
-    /**
-     * 특정 년월의 랭킹 조회 (순위 순)
-     */
-    List<MonthlyRankingMV> findByYearMonthOrderByRankNo(String yearMonth);
-    
-    /**
-     * 특정 년월의 데이터 삭제 (재실행용)
-     */
-    void deleteByYearMonth(String yearMonth);
+
+
+    @Modifying
+    @Query("DELETE FROM MonthlyRankingMV w WHERE w.targetDate = :targetDate")
+    void deleteByTargetDate(@Param("targetDate") LocalDate targetDate);
 }

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/repository/MonthlyRankingRepository.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/repository/MonthlyRankingRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 public interface MonthlyRankingRepository extends JpaRepository<MonthlyRankingMV, Long> {
 
 
-    @Modifying
-    @Query("DELETE FROM MonthlyRankingMV w WHERE w.targetDate = :targetDate")
-    void deleteByTargetDate(@Param("targetDate") LocalDate targetDate);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM MonthlyRankingMV m WHERE m.targetDate = :targetDate")
+    int deleteByTargetDate(@Param("targetDate") LocalDate targetDate);
 }

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/repository/WeeklyRankingRepository.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/repository/WeeklyRankingRepository.java
@@ -7,14 +7,25 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import org.springframework.data.domain.Pageable;
+
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 
 @Repository
 public interface WeeklyRankingRepository extends JpaRepository<WeeklyRankingMV, Long> {
     
 
-    @Modifying
+    List<WeeklyRankingMV> findByTargetDateOrderByRankNoAsc(LocalDate targetDate, Pageable pageable);
+    
+    Optional<WeeklyRankingMV> findByProductIdAndTargetDate(Long productId, LocalDate targetDate);
+    
+    @Query("select max(w.targetDate) from WeeklyRankingMV w where w.targetDate <= :targetDate")
+    LocalDate findLatestTargetDate(@Param("targetDate") LocalDate targetDate);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM WeeklyRankingMV w WHERE w.targetDate = :targetDate")
-    void deleteByTargetDate(@Param("targetDate") LocalDate targetDate);
+    int deleteByTargetDate(@Param("targetDate") LocalDate targetDate);
 }

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/repository/WeeklyRankingRepository.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/repository/WeeklyRankingRepository.java
@@ -2,20 +2,19 @@ package com.loopers.batch.repository;
 
 import com.loopers.batch.domain.entity.WeeklyRankingMV;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.time.LocalDate;
+
 
 @Repository
 public interface WeeklyRankingRepository extends JpaRepository<WeeklyRankingMV, Long> {
     
-    /**
-     * 특정 주차의 랭킹 조회 (순위 순)
-     */
-    List<WeeklyRankingMV> findByYearWeekOrderByRankNo(String yearWeek);
-    
-    /**
-     * 특정 주차의 데이터 삭제 (재실행용)
-     */
-    void deleteByYearWeek(String yearWeek);
+
+    @Modifying
+    @Query("DELETE FROM WeeklyRankingMV w WHERE w.targetDate = :targetDate")
+    void deleteByTargetDate(@Param("targetDate") LocalDate targetDate);
 }

--- a/apps/ranking-batch/src/main/java/com/loopers/batch/repository/WeeklyRankingRepository.java
+++ b/apps/ranking-batch/src/main/java/com/loopers/batch/repository/WeeklyRankingRepository.java
@@ -1,0 +1,21 @@
+package com.loopers.batch.repository;
+
+import com.loopers.batch.domain.entity.WeeklyRankingMV;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface WeeklyRankingRepository extends JpaRepository<WeeklyRankingMV, Long> {
+    
+    /**
+     * 특정 주차의 랭킹 조회 (순위 순)
+     */
+    List<WeeklyRankingMV> findByYearWeekOrderByRankNo(String yearWeek);
+    
+    /**
+     * 특정 주차의 데이터 삭제 (재실행용)
+     */
+    void deleteByYearWeek(String yearWeek);
+}

--- a/apps/ranking-batch/src/main/resources/application.yml
+++ b/apps/ranking-batch/src/main/resources/application.yml
@@ -1,0 +1,81 @@
+server:
+  port: 9090
+
+spring:
+  profiles:
+    active: local
+    
+  application:
+    name: ranking-batch
+    
+  # DataSource 직접 설정
+  datasource:
+    url: jdbc:mysql://localhost:3306/loopers
+    username: application
+    password: application
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+      connection-timeout: 30000
+      
+  # JPA 설정
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+        show_sql: false
+    
+  batch:
+    job:
+      enabled: false  # 자동 실행 방지
+    initialize-schema: never
+    
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 3000ms
+      
+# 배치 설정
+batch:
+  chunk-size: 1000
+  page-size: 1000
+  skip-limit: 100
+  
+# 랭킹 가중치 기본값
+ranking:
+  weights:
+    view: 0.1
+    like: 0.2
+    order: 0.7
+    
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+      
+logging:
+  level:
+    com.loopers.batch: DEBUG
+    org.springframework.batch: DEBUG
+    
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+      
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    
+logging:
+  level:
+    com.loopers.batch: INFO
+    org.springframework.batch: WARN

--- a/apps/ranking-batch/src/main/resources/application.yml
+++ b/apps/ranking-batch/src/main/resources/application.yml
@@ -8,31 +8,18 @@ spring:
   application:
     name: ranking-batch
     
-  # DataSource 직접 설정
-  datasource:
-    url: jdbc:mysql://localhost:3306/loopers
-    username: application
-    password: application
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    hikari:
-      maximum-pool-size: 10
-      minimum-idle: 2
-      connection-timeout: 30000
-      
-  # JPA 설정
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
-        format_sql: true
-        show_sql: false
+  config:
+    import:
+      - jpa.yml
+      - logging.yml
+      - monitoring.yml
     
   batch:
     job:
       enabled: false  # 자동 실행 방지
-    initialize-schema: never
+    jdbc:
+      initialize-schema: always  # Spring Batch 테이블 자동 생성
+      table-prefix: BATCH_
     
   data:
     redis:
@@ -59,6 +46,12 @@ spring:
     activate:
       on-profile: local
       
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 3000ms
+      
 logging:
   level:
     com.loopers.batch: DEBUG
@@ -70,11 +63,12 @@ spring:
     activate:
       on-profile: prod
       
-  datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+      
 logging:
   level:
     com.loopers.batch: INFO

--- a/apps/ranking-batch/src/test/java/com/loopers/batch/job/DailyRankingJobTest.java
+++ b/apps/ranking-batch/src/test/java/com/loopers/batch/job/DailyRankingJobTest.java
@@ -1,0 +1,55 @@
+package com.loopers.batch.job;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Daily Ranking Batch Job 테스트
+ */
+@SpringBootTest
+@SpringBatchTest
+@ActiveProfiles("test")
+class DailyRankingJobTest {
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    @Qualifier("dailyRankingJob")
+    private Job dailyRankingJob;
+
+    @Test
+    void testDailyRankingJob() throws Exception {
+        // JobLauncherTestUtils에 Job 설정
+        jobLauncherTestUtils.setJob(dailyRankingJob);
+
+        // Given
+        String testDate = "2025-09-11"; // 실제 데이터가 있는 날짜
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("targetDate", testDate)
+                .addLong("timestamp", System.currentTimeMillis()) // 유니크한 파라미터 추가
+                .toJobParameters();
+
+        // When
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+        // Then
+        assertThat(jobExecution.getExitStatus().getExitCode()).isEqualTo("COMPLETED");
+        System.out.println("배치 실행 결과: " + jobExecution.getExitStatus());
+//        System.out.println("처리 시간: " + (jobExecution.getEndTime().getTime() - jobExecution.getStartTime().getTime()) + "ms");
+    }
+}

--- a/apps/ranking-batch/src/test/java/com/loopers/batch/job/MonthlyRankingJobTest.java
+++ b/apps/ranking-batch/src/test/java/com/loopers/batch/job/MonthlyRankingJobTest.java
@@ -1,0 +1,50 @@
+package com.loopers.batch.job;
+
+import com.loopers.batch.RankingBatchApplication;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = RankingBatchApplication.class)
+@SpringBatchTest
+@ActiveProfiles("test")
+@Testcontainers
+@Slf4j
+class MonthlyRankingJobTest {
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    @Qualifier("monthlyRankingJob")
+    private Job monthlyRankingJob;
+
+    @BeforeEach
+    void setUp() {
+        jobLauncherTestUtils.setJob(monthlyRankingJob);
+    }
+
+    @Test
+    void testMonthlyRankingJob() throws Exception {
+        String targetDate = "2025-09-30";
+
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob(
+            jobLauncherTestUtils.getUniqueJobParametersBuilder()
+                .addString("targetDate", targetDate)
+                .toJobParameters()
+        );
+
+        assertThat(jobExecution.getExitStatus().getExitCode()).isEqualTo("COMPLETED");
+    }
+}

--- a/apps/ranking-batch/src/test/java/com/loopers/batch/job/WeeklyRankingJobTest.java
+++ b/apps/ranking-batch/src/test/java/com/loopers/batch/job/WeeklyRankingJobTest.java
@@ -1,0 +1,66 @@
+package com.loopers.batch.job;
+
+import com.loopers.batch.RankingBatchApplication;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 주간 랭킹 배치 테스트
+ */
+@SpringBootTest(classes = RankingBatchApplication.class)
+@SpringBatchTest
+@ActiveProfiles("test")
+@Testcontainers
+@Slf4j
+class WeeklyRankingJobTest {
+
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+    
+    @Autowired
+    @Qualifier("weeklyRankingJob")
+    private Job weeklyRankingJob;
+    
+    @BeforeEach
+    void setUp() {
+        jobLauncherTestUtils.setJob(weeklyRankingJob);
+    }
+
+    @Test
+    void testWeeklyRankingJob() throws Exception {
+        // Given
+        String targetDate = "2025-09-13"; // 슬라이딩 윈도우 기준 날짜
+        
+//        log.info("=== 주간 랭킹 배치 테스트 시작 ===");
+//        log.info("대상 날짜: {}", targetDate);
+        
+        // When
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob(
+                jobLauncherTestUtils.getUniqueJobParametersBuilder()
+                        .addString("targetDate", targetDate)
+                        .toJobParameters()
+        );
+        
+        // Then
+        assertThat(jobExecution.getExitStatus().getExitCode()).isEqualTo("COMPLETED");
+//        log.info("=== 주간 랭킹 배치 테스트 완료 ===");
+//        log.info("실행 결과: {}", jobExecution.getExitStatus().getExitCode());
+    }
+}

--- a/apps/ranking-batch/src/test/resources/application-test.yml
+++ b/apps/ranking-batch/src/test/resources/application-test.yml
@@ -1,0 +1,27 @@
+spring:
+  config:
+    import:
+      - jpa.yml
+      
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 1000ms
+
+  batch:
+    job:
+      enabled: false
+    jdbc:
+      initialize-schema: always
+      
+logging:
+  level:
+    com.loopers.batch: DEBUG
+    org.springframework.batch: INFO
+    
+# 테스트용 배치 설정
+batch:
+  chunk-size: 10
+  page-size: 10
+  skip-limit: 5

--- a/modules/jpa/src/main/java/com/loopers/config/jpa/DataSourceConfig.java
+++ b/modules/jpa/src/main/java/com/loopers/config/jpa/DataSourceConfig.java
@@ -17,7 +17,7 @@ class DataSourceConfig {
     }
 
     @Primary
-    @Bean
+    @Bean(name = {"mySqlMainDataSource", "dataSource"})
     HikariDataSource mySqlMainDataSource(@Qualifier("mySqlMainHikariConfig") HikariConfig hikariConfig) {
         return new HikariDataSource(hikariConfig);
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include(
     ":apps:commerce-api",
     ":apps:pg-simulator",
     ":apps:commerce-streamer",
+    ":apps:ranking-batch",
     ":modules:jpa",
     ":modules:redis",
     ":modules:kafka",


### PR DESCRIPTION
# 📌 Summary
주간/월간 랭킹 시스템 구현 (Spring Batch 기반)

- 기존 일간 랭킹(Redis)에 더해 주간/월간 집계 랭킹 시스템 추가
- Spring Batch를 활용한 대용량 데이터 집계 배치 구현
- 슬라이딩 윈도우 방식의 주간 집계 (7일간 데이터)
- PriorityQueue 기반 메모리 효율적 Top 100 선별
- 기존 Ranking API를 확장하여 일간/주간/월간 통합 조회 지원

---

## 💬 Review Points (개정)

1) **TopK 경로 단순화(파티셔닝 포함)**  
   - **배경:** 기존 배치가 원본 재스캔/이중 가중치 계산/PQ 유지로 비용 큼.  
   - **질문:** ZSET carry-over 시점에 상위 구간을 **데일리 요약(일 파티션)**으로 저장하고, **주/월은 요약 합산 + DB Top100(+동점)**으로 자르는 구조가 더 낫지 않을까요?

2) **실무에서 배치를 반드시 쓰는 케이스**  
   - **배경:** 위 1번 같은 구조면 주/월은 얇아져 “배치가 꼭 필요?” 의문.  
   - **질문:** 실제 사례에서 배치가 어떻게 유효했는지 의견 부탁드립니다. 또한 그때 **어떤 기준/지표를 고려**해 선택하셨는지(예: 지연 도착 백필, 대량 재집계, 스냅샷 스왑, 규정·감사 대응 등) **참고 포인트**도 함께 공유해주시면 좋겠습니다.

---

## ✅ Checklist

### 🧱 Spring Batch
- [x] Spring Batch Job 을 작성하고, 파라미터 기반으로 동작시킬 수 있다.
- [x] Chunk Oriented Processing (Reader/Processor/Writer or Tasklet) 기반의 배치 처리를 구현했다.
- [x] 집계 결과를 저장할 Materialized View 의 구조를 설계하고 올바르게 적재했다.

### 🧩 Ranking API
- [x] API 가 일간, 주간, 월간 랭킹을 제공하며 조회해야 하는 형태에 따라 적절한 데이터를 기반으로 랭킹을 제공한다.

---

## 🙏 Closing
10주 동안 정말 감사했습니다. 많은 것을 배웠고, 배운 내용을 실무에 적용해 더 성장하겠습니다. 언젠가 같은 회사에서 함께 일해볼 기회가 온다면 좋겠습니다. 염치없지만 모르는 게 있으면 또 도움 부탁드리겠습니다. 다시 한 번 감사드립니다.

